### PR TITLE
Upgrade: sbt-docusaur 0.1.2 => 0.1.3

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.1.2")
+addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.1.3")


### PR DESCRIPTION
Upgrade: sbt-docusaur 0.1.2 => 0.1.3 - A failed build is no longer published to GitHub Pages